### PR TITLE
Swap parent and child refs: proper 1:many

### DIFF
--- a/superperms/orgs/decorators.py
+++ b/superperms/orgs/decorators.py
@@ -19,7 +19,7 @@ def is_parent_org_owner(org_user):
     """Only allow owners of parent orgs to view child org perms."""
     return (
         org_user.role_level >= ROLE_OWNER and
-        not org_user.organization.parent_org.all().exists()
+        not org_user.organization.parent_org
     )
 
 

--- a/superperms/tests/test_decorators.py
+++ b/superperms/tests/test_decorators.py
@@ -172,7 +172,7 @@ class TestDecorators(TestCase):
         baby_ou = OrganizationUser.objects.create(
             user=self.fake_viewer, organization=baby_org
         )
-        baby_org.parent_org.add(self.fake_org)
+        baby_org.parent_org = self.fake_org
         baby_org.save()
 
         # Even though we're owner for this org, it's not a parent org.

--- a/superperms/tests/test_organizations.py
+++ b/superperms/tests/test_organizations.py
@@ -121,13 +121,13 @@ class TestOrganization(TestCase):
         parent_org = Organization.objects.create(name='Big Daddy')
         child_org = Organization.objects.create(name='Little Sister')
 
-        parent_org.child_org = child_org
-        parent_org.save()
+        child_org.parent_org = parent_org
+        child_org.save()
 
         refreshed_parent = Organization.objects.get(pk=parent_org.pk)
         refreshed_child = Organization.objects.get(pk=child_org.pk)
-        self.assertEqual(refreshed_parent.child_org, refreshed_child)
-        self.assertEqual(refreshed_child.parent_org.all()[0], refreshed_parent)
+        self.assertEqual(refreshed_parent.child_orgs.first(), refreshed_child)
+        self.assertEqual(refreshed_child.parent_org, refreshed_parent)
 
     def test_multi_level_org_nesting(self):
         """Make sure we raise exception if a child tries to make a child."""
@@ -135,10 +135,11 @@ class TestOrganization(TestCase):
         child_org = Organization.objects.create(name='Little Sister')
         baby_org = Organization.objects.create(name='Baby Sister')
 
-        parent_org.child_org = child_org
-        parent_org.save()
+        baby_org.parent_org = child_org # Double nesting
+        baby_org.save()
 
-        child_org.child_org = baby_org # Double nesting
+        child_org.parent_org = parent_org
+
         self.assertRaises(TooManyNestedOrgs, child_org.save)
 
     def test_get_exportable_fields(self):
@@ -165,8 +166,8 @@ class TestOrganization(TestCase):
             list(child_org.get_exportable_fields()), child_fields
         )
 
-        parent_org.child_org = child_org
-        parent_org.save()
+        child_org.parent_org = parent_org
+        child_org.save()
 
         self.assertListEqual(
             list(child_org.get_exportable_fields()), parent_fields
@@ -184,8 +185,9 @@ class TestOrganization(TestCase):
 
         self.assertEqual(child_org.get_query_threshold(), 9)
 
-        parent_org.child_org = child_org
-        parent_org.save()
+
+        child_org.parent_org = parent_org
+        child_org.save()
 
         self.assertEqual(child_org.get_query_threshold(), 10)
 


### PR DESCRIPTION
- This probably means resetting your database -- since these changes won't affect production systems, I'd prefer not to write a data migration here.
